### PR TITLE
病歴機能を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,14 +17,14 @@ class ApplicationController < ActionController::Base
     # グループが存在し、ログインユーザーが所属しているかを確認
     family_group = current_user.family_groups.find_by(id: group_id)
     unless family_group
-      redirect_to family_groups_path, alert: '不正なアクセスです。'
+      redirect_to family_groups_path, alert: "不正なアクセスです。"
       return false
     end
 
     # グループに属しているユーザーか確認
     user = family_group.users.find_by(id: user_id)
     unless user
-      redirect_to family_group_path(group_id), alert: 'このユーザーの情報を見る権限がありません。'
+      redirect_to family_group_path(group_id), alert: "このユーザーの情報を見る権限がありません。"
       return false
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,10 +6,28 @@ class ApplicationController < ActionController::Base
   helper_method :current_user
 
   def require_login
-    redirect_to root_path unless current_user
+    redirect_to root_path, alert: "不正アクセスです。ログインしてください。" unless current_user
   end
 
   def current_user
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
+
+  def validate_group_membership(group_id, user_id)
+    # グループが存在し、ログインユーザーが所属しているかを確認
+    family_group = current_user.family_groups.find_by(id: group_id)
+    unless family_group
+      redirect_to family_groups_path, alert: '不正なアクセスです。'
+      return false
+    end
+
+    # グループに属しているユーザーか確認
+    user = family_group.users.find_by(id: user_id)
+    unless user
+      redirect_to family_group_path(group_id), alert: 'このユーザーの情報を見る権限がありません。'
+      return false
+    end
+
+    true
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,22 +12,4 @@ class ApplicationController < ActionController::Base
   def current_user
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
   end
-
-  def validate_group_membership(group_id, user_id)
-    # グループが存在し、ログインユーザーが所属しているかを確認
-    family_group = current_user.family_groups.find_by(id: group_id)
-    unless family_group
-      redirect_to family_groups_path, alert: "不正なアクセスです。"
-      return false
-    end
-
-    # グループに属しているユーザーか確認
-    user = family_group.users.find_by(id: user_id)
-    unless user
-      redirect_to family_group_path(group_id), alert: "このユーザーの情報を見る権限がありません。"
-      return false
-    end
-
-    true
-  end
 end

--- a/app/controllers/family_groups_controller.rb
+++ b/app/controllers/family_groups_controller.rb
@@ -1,7 +1,7 @@
 class FamilyGroupsController < ApplicationController
   before_action :set_family_group, only: [ :show, :invite_member, :generate_invite ]
   before_action :authorize_family_group, only: [ :show, :invite_member, :generate_invite ]
-  skip_before_action :require_login, only: %i[join]
+  skip_before_action :require_login, only: [ :join ]
 
   def index
     @family_groups = current_user.family_groups

--- a/app/controllers/family_groups_controller.rb
+++ b/app/controllers/family_groups_controller.rb
@@ -48,7 +48,6 @@ class FamilyGroupsController < ApplicationController
         current_user.family_groups << @family_group unless current_user.family_groups.include?(@family_group)
         redirect_to @family_group, notice: 'グループに参加しました。'
       else
-        # セッションに招待トークンを保存
         session[:pending_invite_token] = params[:token]
         redirect_to '/auth/line', notice: 'グループに参加するにはログインしてください。'
       end
@@ -64,7 +63,7 @@ class FamilyGroupsController < ApplicationController
   end
 
   def set_family_group
-    @family_group = FamilyGroup.find(params[:id])
+    @family_group = FamilyGroup.find_by(id: params[:id])
   end
 
   def authorize_family_group

--- a/app/controllers/family_groups_controller.rb
+++ b/app/controllers/family_groups_controller.rb
@@ -1,6 +1,6 @@
 class FamilyGroupsController < ApplicationController
-  before_action :set_family_group, only: [:show, :invite_member, :generate_invite]
-  before_action :authorize_family_group, only: [:show, :invite_member, :generate_invite]
+  before_action :set_family_group, only: [ :show, :invite_member, :generate_invite ]
+  before_action :authorize_family_group, only: [ :show, :invite_member, :generate_invite ]
   skip_before_action :require_login, only: %i[join]
 
   def index
@@ -29,16 +29,16 @@ class FamilyGroupsController < ApplicationController
     user = User.find_by(email: params[:email])
     if user
       @family_group.users << user
-      redirect_to @family_group, notice: 'メンバーが招待されました。'
+      redirect_to @family_group, notice: "メンバーが招待されました。"
     else
-      redirect_to @family_group, alert: 'ユーザーが見つかりません。'
+      redirect_to @family_group, alert: "ユーザーが見つかりません。"
     end
   end
 
   def generate_invite
     @family_group.generate_invite_token
     @invite_url = join_family_group_url(@family_group.invite_token)
-    redirect_to family_group_path(@family_group), notice: '招待リンクが生成されました！'
+    redirect_to family_group_path(@family_group), notice: "招待リンクが生成されました！"
   end
 
   def join
@@ -46,13 +46,13 @@ class FamilyGroupsController < ApplicationController
     if @family_group
       if current_user
         current_user.family_groups << @family_group unless current_user.family_groups.include?(@family_group)
-        redirect_to @family_group, notice: 'グループに参加しました。'
+        redirect_to @family_group, notice: "グループに参加しました。"
       else
         session[:pending_invite_token] = params[:token]
-        redirect_to '/auth/line', notice: 'グループに参加するにはログインしてください。'
+        redirect_to "/auth/line", notice: "グループに参加するにはログインしてください。"
       end
     else
-      redirect_to root_path, alert: '無効な招待リンクです。'
+      redirect_to root_path, alert: "無効な招待リンクです。"
     end
   end
 
@@ -68,7 +68,7 @@ class FamilyGroupsController < ApplicationController
 
   def authorize_family_group
     unless current_user.family_groups.include?(@family_group)
-      redirect_to family_groups_path, alert: 'アクセス権限がありません。'
+      redirect_to family_groups_path, alert: "アクセス権限がありません。"
     end
   end
 end

--- a/app/controllers/medical_histories_controller.rb
+++ b/app/controllers/medical_histories_controller.rb
@@ -1,22 +1,48 @@
 class MedicalHistoriesController < ApplicationController
+  before_action :set_medical_history, only: [ :show, :edit, :update, :destroy ]
+
   def index
+    @medical_histories = current_user.medical_histories.order(age_at_diagnosis: :asc)
   end
 
-  def show
-  end
+  def show; end
 
   def new
+    @medical_history = MedicalHistory.new
   end
 
   def create
+    @medical_history = current_user.medical_histories.build(medical_history_params)
+    if @medical_history.save
+      redirect_to medical_histories_path, notice: "病歴を登録しました。"
+    else
+      flash[:alert] = '新規登録に失敗しました'
+      render :new, status: :unprocessable_entity
+    end
   end
 
-  def edit
-  end
+  def edit; end
 
   def update
+    if @medical_history.update(medical_history_params)
+      redirect_to medical_histories_path, notice: "病歴を更新しました。"
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def destroy
+    @medical_history.destroy!
+    redirect_to medical_histories_path, success: "選択した病歴を削除しました"
+  end
+
+  private
+
+  def medical_history_params
+    params.require(:medical_history).permit(:disease, :age_at_diagnosis, :treatment_status, :disease_notes)
+  end
+
+  def set_medical_history
+    @medical_history = current_user.medical_histories.find(params[:id])
   end
 end

--- a/app/controllers/medical_histories_controller.rb
+++ b/app/controllers/medical_histories_controller.rb
@@ -16,7 +16,7 @@ class MedicalHistoriesController < ApplicationController
     if @medical_history.save
       redirect_to medical_histories_path, notice: "病歴を登録しました。"
     else
-      flash[:alert] = '新規登録に失敗しました'
+      flash[:alert] = "新規登録に失敗しました"
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,7 +4,7 @@ class SessionsController < ApplicationController
   def create
     user_info = request.env["omniauth.auth"]
     hashed_uid = User.hash_uid(user_info["uid"]) # UIDをハッシュ化
-  
+
     # ハッシュ化されたUIDでユーザーを検索または作成
     user = User.find_or_create_by(hashed_uid: hashed_uid) do |u|
       u.name = user_info["info"]["name"]
@@ -33,10 +33,10 @@ class SessionsController < ApplicationController
     if family_group
       current_user.family_groups << family_group unless current_user.family_groups.include?(family_group)
       session.delete(:pending_invite_token)
-      redirect_to family_group_path(family_group), notice: 'ログインしてグループに参加しました。'
+      redirect_to family_group_path(family_group), notice: "ログインしてグループに参加しました。"
     else
       session.delete(:pending_invite_token)
-      redirect_to family_groups_path, alert: '無効な招待リンクです。'
+      redirect_to family_groups_path, alert: "無効な招待リンクです。"
     end
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,5 @@
 class StaticPagesController < ApplicationController
-  skip_before_action :require_login, only: %i[top]
+  skip_before_action :require_login, only: [:top]
 
   def top; end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,5 @@
 class StaticPagesController < ApplicationController
-  skip_before_action :require_login, only: [:top]
+  skip_before_action :require_login, only: [ :top ]
 
   def top; end
 end

--- a/app/controllers/users/medical_histories_controller.rb
+++ b/app/controllers/users/medical_histories_controller.rb
@@ -1,0 +1,39 @@
+class Users::MedicalHistoriesController < ApplicationController
+  before_action :set_group
+  before_action :set_user, only: [:index, :show]
+  before_action :set_medical_history, only: [:show]
+
+  def index
+    @medical_histories = @user.medical_histories
+  end
+
+  def show
+  end
+
+  private
+
+  def set_group
+    @from_family_group = params[:from_family_group]
+    @group = current_user.family_groups.find_by(id: @from_family_group)
+
+    unless @group
+      redirect_to family_groups_path, alert: "不正なアクセスです。"
+    end
+  end
+
+  def set_user
+    @user = @group.users.find_by(id: params[:user_id])
+
+    unless @user
+      redirect_to family_group_path(@group), alert: "指定されたユーザーが見つかりません。"
+    end
+  end
+
+  def set_medical_history
+    @medical_history = @user.medical_histories.find_by(id: params[:id])
+
+    unless @medical_history
+      redirect_to user_medical_histories_path(user_id: @user.id, from_family_group: @from_family_group), alert: "指定された病歴が見つかりません。"
+    end
+  end
+end

--- a/app/controllers/users/medical_histories_controller.rb
+++ b/app/controllers/users/medical_histories_controller.rb
@@ -1,7 +1,7 @@
 class Users::MedicalHistoriesController < ApplicationController
   before_action :set_group
-  before_action :set_user, only: [:index, :show]
-  before_action :set_medical_history, only: [:show]
+  before_action :set_user, only: [ :index, :show ]
+  before_action :set_medical_history, only: [ :show ]
 
   def index
     @medical_histories = @user.medical_histories

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,19 +1,19 @@
 class UsersController < ApplicationController
-  before_action :set_current_user, only: [:edit, :update]
-  before_action :validate_user_group_membership, only: [:show]
+  before_action :set_current_user, only: [ :edit, :update ]
+  before_action :validate_user_group_membership, only: [ :show ]
 
   def show
     @user = User.find_by(id: params[:id])
     @from_family_group = params[:from_family_group]
   end
-  
+
   def edit; end
 
   def update
     if @user.update(user_params)
       redirect_to root_path, notice: "更新しました"
     else
-      flash.now['danger'] = t('defaults.flash_message.not_updated', item: User.model_name.human)
+      flash.now["danger"] = t("defaults.flash_message.not_updated", item: User.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -39,7 +39,7 @@ class UsersController < ApplicationController
 
     user = family_group.users.find_by(id: user_id)
     unless user
-      redirect_to family_group_path(group_id), alert: "このユーザーの情報を見る権限がありません。"
+      redirect_to family_group_path(group_id), alert: "指定されたユーザーが見つかりません。"
       return false
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,6 @@ class UsersController < ApplicationController
     if @user.update(user_params)
       redirect_to root_path, notice: "更新しました"
     else
-      flash.now["danger"] = t("defaults.flash_message.not_updated", item: User.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end
@@ -31,6 +30,19 @@ class UsersController < ApplicationController
   def validate_user_group_membership
     group_id = params[:from_family_group]
     user_id = params[:id]
-    validate_group_membership(group_id, user_id)
+
+    family_group = current_user.family_groups.find_by(id: group_id)
+    unless family_group
+      redirect_to family_groups_path, alert: "不正なアクセスです。"
+      return false
+    end
+
+    user = family_group.users.find_by(id: user_id)
+    unless user
+      redirect_to family_group_path(group_id), alert: "このユーザーの情報を見る権限がありません。"
+      return false
+    end
+
+    true
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :set_current_user, only: %i[edit update]
+  before_action :set_current_user, only: [:edit, :update]
   before_action :validate_user_group_membership, only: [:show]
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :set_current_user, only: %i[edit update]
-  before_action :validate_group_membership, only: [:show]
+  before_action :validate_user_group_membership, only: [:show]
 
   def show
     @user = User.find_by(id: params[:id])
@@ -28,22 +28,9 @@ class UsersController < ApplicationController
     params.require(:user).permit(:name, :gender, :birth_date, :blood_type)
   end
 
-  # グループとユーザーの関連性を検証
-  def validate_group_membership
+  def validate_user_group_membership
     group_id = params[:from_family_group]
     user_id = params[:id]
-
-    # グループが存在し、ログインユーザーが所属しているかを確認
-    family_group = current_user.family_groups.find_by(id: group_id)
-    unless family_group
-      redirect_to family_groups_path, alert: '不正なアクセスです。'
-      return
-    end
-
-    # グループに属しているユーザーか確認
-    user = family_group.users.find_by(id: user_id)
-    unless user
-      redirect_to family_group_path(group_id), alert: 'このユーザーの詳細を見る権限がありません。'
-    end
+    validate_group_membership(group_id, user_id)
   end
 end

--- a/app/models/medical_history.rb
+++ b/app/models/medical_history.rb
@@ -3,7 +3,6 @@ class MedicalHistory < ApplicationRecord
 
   encrypts :disease
   encrypts :treatment_status
-  encrypts :age_at_diagnosis
   encrypts :disease_notes
 
   validates :disease, presence: true, length: { maximum: 100 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   validates :hashed_uid, uniqueness: true
 
   enum gender: { 男性: 0, 女性: 1, その他: 2 }
-  enum blood_type: { A型: 0, B型: 1, O型: 2, AB型: 3 ,不明: 4}
+  enum blood_type: { A型: 0, B型: 1, O型: 2, AB型: 3, 不明: 4 }
 
   # UIDをハッシュ化するメソッド
   def self.hash_uid(uid)

--- a/app/views/family_groups/_family_group.html.erb
+++ b/app/views/family_groups/_family_group.html.erb
@@ -1,7 +1,0 @@
-<% @family_groups.each do |group| %>
-  <div class="bg-white shadow-md rounded-lg p-4 text-left">
-    <h3 class="text-lg font-bold text-gray-800">
-      <%= link_to group.name, family_group_path(group.id), class: "text-blue-500 hover:underline" %>
-    </h3>
-  </div>
-<% end %>

--- a/app/views/family_groups/index.html.erb
+++ b/app/views/family_groups/index.html.erb
@@ -18,6 +18,6 @@
   </div>
 
   <div class="mt-4">
-    <%= link_to 'ログアウト', logout_path, class: "inline-block px-5 py-3 bg-red-500 text-white rounded-lg hover:bg-red-600" %>
+    <%= link_to "ログアウト", logout_path, class: "inline-block px-5 py-3 bg-red-500 text-white rounded-lg hover:bg-red-600" %>
   </div>
 </div>

--- a/app/views/family_groups/index.html.erb
+++ b/app/views/family_groups/index.html.erb
@@ -1,7 +1,13 @@
 <div class="container mx-auto mt-10 text-center">
   <h1 class="text-2xl font-bold text-gray-700 mb-5">所属している家族グループ一覧</h1>
   <div id="family_groups" class="grid grid-cols-1 md:grid-cols-2 gap-6">
-    <%= render "family_group" %>
+    <% @family_groups.each do |group| %>
+      <div class="bg-white shadow-md rounded-lg p-4 text-left">
+        <h3 class="text-lg font-bold text-gray-800">
+          <%= link_to group.name, family_group_path(group.id), class: "text-blue-500 hover:underline" %>
+        </h3>
+      </div>
+    <% end %>
   </div>
   <div class="mt-6">
     <%= link_to "家族グループを新規作成する", new_family_group_path, class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>

--- a/app/views/family_groups/new.html.erb
+++ b/app/views/family_groups/new.html.erb
@@ -12,6 +12,6 @@
     <% end %>
   </div>
   <div class="mt-10">
-    <%= link_to '所属している家族グループ一覧へ', family_groups_path, class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
+    <%= link_to "所属している家族グループ一覧へ", family_groups_path, class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
   </div>
 </div>

--- a/app/views/family_groups/show.html.erb
+++ b/app/views/family_groups/show.html.erb
@@ -31,14 +31,14 @@
     </div>
   <% else %>
     <%= form_with(url: generate_invite_family_group_path(@family_group), local: true, method: :post, style: "text-align: center;") do %>
-      <%= submit_tag '招待リンクを生成', 
+      <%= submit_tag "招待リンクを生成", 
           style: "padding: 10px 15px; font-size: 14px; color: #fff; background-color: #4CAF50; border: none; border-radius: 5px; cursor: pointer;" %>
     <% end %>
   <% end %>
 </div>
 
   <div class="mt-10">
-    <%= link_to '所属している家族グループ一覧へ', family_groups_path, class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
+    <%= link_to "所属している家族グループ一覧へ", family_groups_path, class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
   </div>
 
   <div class="mt-4">
@@ -46,14 +46,14 @@
   </div>
 
   <div class="mt-4">
-    <%= link_to 'ログアウト', logout_path, class: "inline-block px-5 py-3 bg-red-500 text-white rounded-lg hover:bg-red-600" %>
+    <%= link_to "ログアウト", logout_path, class: "inline-block px-5 py-3 bg-red-500 text-white rounded-lg hover:bg-red-600" %>
   </div>
 
 <script>
 function copyToClipboard() {
-  var copyText = document.querySelector('input[readonly]');
+  var copyText = document.querySelector("input[readonly]");
   copyText.select();
-  document.execCommand('copy');
-  alert('招待リンクをコピーしました！');
+  document.execCommand("copy");
+  alert("招待リンクをコピーしました！");
 }
 </script>

--- a/app/views/medical_histories/_form.html.erb
+++ b/app/views/medical_histories/_form.html.erb
@@ -25,7 +25,7 @@
     </div>
 
     <div style="text-align: center; margin-top: 20px;">
-      <%= f.submit nil, class: "inline-block px-5 py-3 bg-green-500 text-white rounded hover:bg-green-600" %>
+      <%= f.submit f.object.new_record? ? "登録" : "更新", class: "inline-block px-5 py-3 bg-green-500 text-white rounded hover:bg-green-600" %>
     </div>
   <% end %>
 

--- a/app/views/medical_histories/_form.html.erb
+++ b/app/views/medical_histories/_form.html.erb
@@ -1,7 +1,7 @@
 <div style="border: 1px solid #ddd; border-radius: 8px; padding: 20px; max-width: 600px; margin: auto;">
   <%= form_with(model: @medical_history, local: true) do |f| %>
     <h1 style="text-align: center; color: #4CAF50; margin-bottom: 20px;">
-      <%= medical_history.new_record? ? '病歴を新規登録' : '病歴を編集' %>
+      <%= medical_history.new_record? ? "病歴を新規登録" : "病歴を編集" %>
     </h1>
 
     <div style="margin-bottom: 15px;">
@@ -30,6 +30,6 @@
   <% end %>
 
   <div class="mt-4" style="text-align: center;">
-    <%= link_to 'キャンセル', medical_histories_path, class: "inline-block px-5 py-3 bg-gray-500 text-white rounded hover:bg-gray-600" %>
+    <%= link_to "キャンセル", medical_histories_path, class: "inline-block px-5 py-3 bg-gray-500 text-white rounded hover:bg-gray-600" %>
   </div>
 </div>

--- a/app/views/medical_histories/_form.html.erb
+++ b/app/views/medical_histories/_form.html.erb
@@ -1,0 +1,35 @@
+<div style="border: 1px solid #ddd; border-radius: 8px; padding: 20px; max-width: 600px; margin: auto;">
+  <%= form_with(model: @medical_history, local: true) do |f| %>
+    <h1 style="text-align: center; color: #4CAF50; margin-bottom: 20px;">
+      <%= medical_history.new_record? ? '病歴を新規登録' : '病歴を編集' %>
+    </h1>
+
+    <div style="margin-bottom: 15px;">
+      <%= f.label :disease, "病名", style: "font-size: 16px; color: #555;" %><br>
+      <%= f.text_field :disease, required: true, class: "w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
+
+    <div style="margin-bottom: 15px;">
+      <%= f.label :age_at_diagnosis, "発症年齢", style: "font-size: 16px; color: #555;" %><br>
+      <%= f.number_field :age_at_diagnosis, class: "w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
+
+    <div style="margin-bottom: 15px;">
+      <%= f.label :treatment_status, "治療状況", style: "font-size: 16px; color: #555;" %><br>
+      <%= f.text_field :treatment_status, class: "w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
+
+    <div style="margin-bottom: 15px;">
+      <%= f.label :disease_notes, "備考", style: "font-size: 16px; color: #555;" %><br>
+      <%= f.text_area :disease_notes, rows: 5, class: "w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
+
+    <div style="text-align: center; margin-top: 20px;">
+      <%= f.submit nil, class: "inline-block px-5 py-3 bg-green-500 text-white rounded hover:bg-green-600" %>
+    </div>
+  <% end %>
+
+  <div class="mt-4" style="text-align: center;">
+    <%= link_to 'キャンセル', medical_histories_path, class: "inline-block px-5 py-3 bg-gray-500 text-white rounded hover:bg-gray-600" %>
+  </div>
+</div>

--- a/app/views/medical_histories/edit.html.erb
+++ b/app/views/medical_histories/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form', medical_history: @medical_history %>

--- a/app/views/medical_histories/edit.html.erb
+++ b/app/views/medical_histories/edit.html.erb
@@ -1,1 +1,1 @@
-<%= render 'form', medical_history: @medical_history %>
+<%= render "form", medical_history: @medical_history %>

--- a/app/views/medical_histories/index.html.erb
+++ b/app/views/medical_histories/index.html.erb
@@ -15,7 +15,7 @@
           <td style="padding: 10px; border: 1px solid #ddd;"><%= history.age_at_diagnosis %></td>
           <td style="padding: 10px; border: 1px solid #ddd;"><%= history.disease %></td>
           <td style="padding: 10px; border: 1px solid #ddd;">
-            <%= link_to '詳細を見る', medical_history_path(history.id), class: "inline-block px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+            <%= link_to "詳細を見る", medical_history_path(history.id), class: "inline-block px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
           </td>
         </tr>
       <% end %>

--- a/app/views/medical_histories/index.html.erb
+++ b/app/views/medical_histories/index.html.erb
@@ -1,0 +1,31 @@
+<h1 style="text-align: center; color: #4CAF50; margin-bottom: 20px;">病歴一覧</h1>
+
+<div style="max-width: 800px; margin: auto;">
+  <table style="width: 100%; border-collapse: collapse; border: 1px solid #ddd;">
+    <thead>
+      <tr style="background-color: #f9f9f9; color: #333;">
+      <th style="padding: 10px; border: 1px solid #ddd; text-align: left;">発症年齢</th>
+        <th style="padding: 10px; border: 1px solid #ddd; text-align: left;">病名</th>
+        <th style="padding: 10px; border: 1px solid #ddd; text-align: left;">詳細</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @medical_histories.each do |history| %>
+        <tr>
+          <td style="padding: 10px; border: 1px solid #ddd;"><%= history.age_at_diagnosis %></td>
+          <td style="padding: 10px; border: 1px solid #ddd;"><%= history.disease %></td>
+          <td style="padding: 10px; border: 1px solid #ddd;">
+            <%= link_to '詳細を見る', medical_history_path(history.id), class: "inline-block px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <div class="mt-10" style="text-align: center;">
+    <%= link_to "新規病歴登録画面へ", new_medical_history_path(current_user), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+  </div>
+  <div class="mt-6" style="text-align: center;">
+    <%= link_to "トップへ戻る", root_path, class: "inline-block px-5 py-3 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+  </div>
+</div>

--- a/app/views/medical_histories/new.html.erb
+++ b/app/views/medical_histories/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form', medical_history: @medical_history %>

--- a/app/views/medical_histories/new.html.erb
+++ b/app/views/medical_histories/new.html.erb
@@ -1,1 +1,1 @@
-<%= render 'form', medical_history: @medical_history %>
+<%= render "form", medical_history: @medical_history %>

--- a/app/views/medical_histories/show.html.erb
+++ b/app/views/medical_histories/show.html.erb
@@ -1,0 +1,27 @@
+<h1 style="text-align: center; color: #4CAF50; margin-bottom: 20px;">病歴詳細</h1>
+
+<div style="border: 1px solid #ddd; border-radius: 8px; padding: 20px; max-width: 600px; margin: auto;">
+  <h2 style="color: #555;">病名：</h2>
+  <p style="font-size: 18px; color: #333; font-weight: bold"><%= @medical_history.disease %></p>
+
+  <h2 style="color: #555;">発症年齢：</h2>
+  <p style="font-size: 18px; color: #333;"><%= @medical_history.age_at_diagnosis %></p>
+
+  <h2 style="color: #555;">治療状況：</h2>
+  <p style="font-size: 18px; color: #333;"><%= @medical_history.treatment_status.presence || "未記入" %></p>
+
+  <h2 style="color: #555;">備考：</h2>
+  <p style="font-size: 18px; color: #333; white-space: pre-wrap;"><%= @medical_history.disease_notes.presence || "なし" %></p>
+
+  <div class="mt-10" style="text-align: center;">
+    <%= link_to '編集する', edit_medical_history_path(@medical_history),
+                class: "inline-block px-5 py-3 bg-green-500 text-white rounded hover:bg-green-600" %>
+    <%= link_to '削除する', medical_history_path(@medical_history),
+                id: "button-delete-#{@medical_history.id}", data: { turbo_method: :delete, turbo_confirm: "本当に削除して良いですか？" },
+                class: "inline-block px-5 py-3 bg-orange-500 text-white rounded hover:bg-orange-600" %>
+  </div>
+  <div class="mt-6" style="text-align: center;">
+    <%= link_to '一覧に戻る', medical_histories_path, class: "inline-block px-5 py-3 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+    <%= link_to "トップへ戻る", root_path, class: "inline-block px-5 py-3 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+  </div>
+</div>

--- a/app/views/medical_histories/show.html.erb
+++ b/app/views/medical_histories/show.html.erb
@@ -14,14 +14,14 @@
   <p style="font-size: 18px; color: #333; white-space: pre-wrap;"><%= @medical_history.disease_notes.presence || "なし" %></p>
 
   <div class="mt-10" style="text-align: center;">
-    <%= link_to '編集する', edit_medical_history_path(@medical_history),
+    <%= link_to "編集する", edit_medical_history_path(@medical_history),
                 class: "inline-block px-5 py-3 bg-green-500 text-white rounded hover:bg-green-600" %>
-    <%= link_to '削除する', medical_history_path(@medical_history),
+    <%= link_to "削除する", medical_history_path(@medical_history),
                 id: "button-delete-#{@medical_history.id}", data: { turbo_method: :delete, turbo_confirm: "本当に削除して良いですか？" },
                 class: "inline-block px-5 py-3 bg-orange-500 text-white rounded hover:bg-orange-600" %>
   </div>
   <div class="mt-6" style="text-align: center;">
-    <%= link_to '一覧に戻る', medical_histories_path, class: "inline-block px-5 py-3 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+    <%= link_to "一覧に戻る", medical_histories_path, class: "inline-block px-5 py-3 bg-blue-500 text-white rounded hover:bg-blue-600" %>
     <%= link_to "トップへ戻る", root_path, class: "inline-block px-5 py-3 bg-blue-500 text-white rounded hover:bg-blue-600" %>
   </div>
 </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -6,22 +6,22 @@
   <% if current_user %>
     <p class="text-gray-800">ようこそ、<span class="font-bold"><%= current_user.name %></span>さん</p>
     <div class="mt-10">
-      <%= link_to '所属している家族グループ一覧へ', family_groups_path, class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
+      <%= link_to "所属している家族グループ一覧へ", family_groups_path, class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
     </div>
     <div class="mt-4">
-      <%= link_to '個人情報の登録画面へ', edit_user_path(current_user), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
+      <%= link_to "個人情報の登録画面へ", edit_user_path(current_user), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
     </div>
     <div class="mt-4">
-      <%= link_to '自分の病歴一覧へ', medical_histories_path(current_user), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
+      <%= link_to "自分の病歴一覧へ", medical_histories_path(current_user), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
     </div>
     <div class="mt-10">
-      <%= link_to 'ログアウト', logout_path, class: "inline-block px-5 py-3 bg-red-500 text-white rounded-lg hover:bg-red-600" %>
+      <%= link_to "ログアウト", logout_path, class: "inline-block px-5 py-3 bg-red-500 text-white rounded-lg hover:bg-red-600" %>
     </div>
   <% end %>
 
   <% unless current_user %>
     <div class="mt-6">
-      <%= link_to image_tag('btn_login_base.png', class: "mx-auto w-48"), '/auth/line' %>
+      <%= link_to image_tag("btn_login_base.png", class: "mx-auto w-48"), "/auth/line" %>
     </div>
   <% end %>
 </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -11,6 +11,9 @@
     <div class="mt-4">
       <%= link_to '個人情報の登録画面へ', edit_user_path(current_user), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
     </div>
+    <div class="mt-4">
+      <%= link_to '自分の病歴一覧へ', medical_histories_path(current_user), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
+    </div>
     <div class="mt-10">
       <%= link_to 'ログアウト', logout_path, class: "inline-block px-5 py-3 bg-red-500 text-white rounded-lg hover:bg-red-600" %>
     </div>

--- a/app/views/users/medical_histories/index.html.erb
+++ b/app/views/users/medical_histories/index.html.erb
@@ -1,4 +1,6 @@
-<h1 style="text-align: center; color: #4CAF50; margin-bottom: 20px;">病歴一覧</h1>
+<h1 style="text-align: center; color: #4CAF50; margin-bottom: 20px;">
+  <%= @user.name %>の病歴一覧
+</h1>
 
 <div style="max-width: 800px; margin: auto;">
   <table style="width: 100%; border-collapse: collapse; border: 1px solid #ddd;">

--- a/app/views/users/medical_histories/index.html.erb
+++ b/app/views/users/medical_histories/index.html.erb
@@ -1,0 +1,28 @@
+<h1 style="text-align: center; color: #4CAF50; margin-bottom: 20px;">病歴一覧</h1>
+
+<div style="max-width: 800px; margin: auto;">
+  <table style="width: 100%; border-collapse: collapse; border: 1px solid #ddd;">
+    <thead>
+      <tr style="background-color: #f9f9f9; color: #333;">
+      <th style="padding: 10px; border: 1px solid #ddd; text-align: left;">発症年齢</th>
+        <th style="padding: 10px; border: 1px solid #ddd; text-align: left;">病名</th>
+        <th style="padding: 10px; border: 1px solid #ddd; text-align: left;">詳細</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @medical_histories.each do |history| %>
+        <tr>
+          <td style="padding: 10px; border: 1px solid #ddd;"><%= history.age_at_diagnosis %></td>
+          <td style="padding: 10px; border: 1px solid #ddd;"><%= history.disease %></td>
+          <td style="padding: 10px; border: 1px solid #ddd;">
+            <%= link_to '詳細を見る', user_medical_history_path(history.user, history.id, from_family_group: @from_family_group), class: "inline-block px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <div class="mt-6" style="text-align: center;">
+    <%= link_to "基本情報へ戻る", user_path(@user, from_family_group: @group.id), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+  </div>
+</div>

--- a/app/views/users/medical_histories/index.html.erb
+++ b/app/views/users/medical_histories/index.html.erb
@@ -15,7 +15,7 @@
           <td style="padding: 10px; border: 1px solid #ddd;"><%= history.age_at_diagnosis %></td>
           <td style="padding: 10px; border: 1px solid #ddd;"><%= history.disease %></td>
           <td style="padding: 10px; border: 1px solid #ddd;">
-            <%= link_to '詳細を見る', user_medical_history_path(history.user, history.id, from_family_group: @from_family_group), class: "inline-block px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+            <%= link_to "詳細を見る", user_medical_history_path(history.user, history.id, from_family_group: @from_family_group), class: "inline-block px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
           </td>
         </tr>
       <% end %>

--- a/app/views/users/medical_histories/show.html.erb
+++ b/app/views/users/medical_histories/show.html.erb
@@ -15,7 +15,7 @@
 
   <div class="mt-6" style="text-align: center;">
     <%= link_to "基本情報へ戻る", user_path(@medical_history.user, from_family_group: @from_family_group), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-    <%= link_to '病歴一覧へ戻る', user_medical_histories_path(@medical_history.user, from_family_group: @from_family_group), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+    <%= link_to "病歴一覧へ戻る", user_medical_histories_path(@medical_history.user, from_family_group: @from_family_group), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded hover:bg-blue-600" %>
   </div>
   <div class="mt-6" style="text-align: center;">
     <%= link_to "家族メンバー一覧へ戻る", family_group_path(@from_family_group), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded hover:bg-blue-600" %>

--- a/app/views/users/medical_histories/show.html.erb
+++ b/app/views/users/medical_histories/show.html.erb
@@ -1,0 +1,23 @@
+<h1 style="text-align: center; color: #4CAF50; margin-bottom: 20px;">病歴詳細</h1>
+
+<div style="border: 1px solid #ddd; border-radius: 8px; padding: 20px; max-width: 600px; margin: auto;">
+  <h2 style="color: #555;">病名：</h2>
+  <p style="font-size: 18px; color: #333; font-weight: bold"><%= @medical_history.disease %></p>
+
+  <h2 style="color: #555;">発症年齢：</h2>
+  <p style="font-size: 18px; color: #333;"><%= @medical_history.age_at_diagnosis %></p>
+
+  <h2 style="color: #555;">治療状況：</h2>
+  <p style="font-size: 18px; color: #333;"><%= @medical_history.treatment_status.presence || "未記入" %></p>
+
+  <h2 style="color: #555;">備考：</h2>
+  <p style="font-size: 18px; color: #333; white-space: pre-wrap;"><%= @medical_history.disease_notes.presence || "なし" %></p>
+
+  <div class="mt-6" style="text-align: center;">
+    <%= link_to "基本情報へ戻る", user_path(@medical_history.user, from_family_group: @from_family_group), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+    <%= link_to '病歴一覧へ戻る', user_medical_histories_path(@medical_history.user, from_family_group: @from_family_group), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+  </div>
+  <div class="mt-6" style="text-align: center;">
+    <%= link_to "家族メンバー一覧へ戻る", family_group_path(@from_family_group), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+  </div>
+</div>

--- a/app/views/users/medical_histories/show.html.erb
+++ b/app/views/users/medical_histories/show.html.erb
@@ -1,4 +1,6 @@
-<h1 style="text-align: center; color: #4CAF50; margin-bottom: 20px;">病歴詳細</h1>
+<h1 style="text-align: center; color: #4CAF50; margin-bottom: 20px;">
+  <%= @user.name %>の病歴詳細
+</h1>
 
 <div style="border: 1px solid #ddd; border-radius: 8px; padding: 20px; max-width: 600px; margin: auto;">
   <h2 style="color: #555;">病名：</h2>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,7 +18,7 @@
   </div>
 
   <div class="mt-4">
-    <%= link_to '家族メンバー一覧へ戻る', family_group_path(@from_family_group), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
+    <%= link_to "家族メンバー一覧へ戻る", family_group_path(@from_family_group), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
   </div>
 </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,11 +12,16 @@
     <h2 style="color: #555;">血液型：</h2>
   <p style="font-size: 18px; color: #333;"><%= @user.blood_type %></p>
 
-  <div class="mt-10">
-    <%= link_to '戻る', family_group_path(@from_family_group), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
+
+  <div class="mt-4">
+    <%= link_to "病歴一覧へ", user_medical_histories_path(@user, from_family_group: @from_family_group), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
   </div>
 
   <div class="mt-4">
-    <%= link_to "トップへ戻る", root_path, class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
+    <%= link_to '家族メンバー一覧へ戻る', family_group_path(@from_family_group), class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
   </div>
+</div>
+
+<div class="mt-10">
+<%= link_to "トップへ戻る", root_path, class: "inline-block px-5 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600" %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,9 @@ Rails.application.routes.draw do
 
   # MVP時点ではアカウントのあるユーザーのみに対応、退会機能未実装。
   # アカウントの無い人用に、newやdestroyが必要になる可能性あり。
-  resources :users, only: %i[show edit update]
-  resources :medical_histories
+  resources :users, only: %i[show edit update] do
+    resources :medical_histories
+  end
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,8 +19,9 @@ Rails.application.routes.draw do
   # MVP時点ではアカウントのあるユーザーのみに対応、退会機能未実装。
   # アカウントの無い人用に、newやdestroyが必要になる可能性あり。
   resources :users, only: %i[show edit update] do
-    resources :medical_histories
+    resources :medical_histories, only: %i[index show]
   end
+  resources :medical_histories
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   # MVP時点ではアカウントのあるユーザーのみに対応、退会機能未実装。
   # アカウントの無い人用に、newやdestroyが必要になる可能性あり。
   resources :users, only: %i[show edit update] do
-    resources :medical_histories, only: %i[index show]
+    resources :medical_histories, only: %i[index show], module: :users
   end
   resources :medical_histories
 


### PR DESCRIPTION
- 自身の病歴一覧、詳細からは新規登録、編集、削除が可能
- グループからアクセスした場合は、病歴一覧、詳細のみが閲覧可能

以下のようにルーティングから分岐することで実装。
```
  resources :users, only: %i[show edit update] do
    resources :medical_histories, only: %i[index show], module: :users
  end
  resources :medical_histories
```

また、URLのid指定で、アクセス権のないユーザーがアクセスできないようにした。